### PR TITLE
Change hyphen / word wrap in README_POST_INSTALL_DE

### DIFF
--- a/appcenter/README_POST_INSTALL_DE
+++ b/appcenter/README_POST_INSTALL_DE
@@ -1,7 +1,7 @@
 <p>
   PLUCS ist nun auf Ihrem Server installiert. Sie können den Dienst sofort
-  nutzen. Hier sind die Arbeitsschritte, mit denen Sie den Dienst administrie-
-  ren können:
+  nutzen. Hier sind die Arbeitsschritte, mit denen Sie den Dienst
+  administrieren können:
 
   <ol>
     <li>


### PR DESCRIPTION
This is just a minor visual improvement.
(And my first "official" PR on GitHub. Please bear with me.)

The hyphenation used with "administrieren" looks a bit odd when displayed in the App Center:
![069_auswahl](https://cloud.githubusercontent.com/assets/8418423/14739659/580278a4-0889-11e6-9bdf-cec5b71c8ed7.png)
I simply removed the hyphen and pushed "administrieren" down a line.
